### PR TITLE
d/t/basic-smoke: use archive.d.o as the MIRROR URL 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,10 @@ docker.io-app (28.2.2-0ubuntu1~22.04.1) jammy; urgency=medium
   * Backport from questing to jammy (LP: #2112523)
   * d/control: b-d on golang-1.23-go instead of golang-1.24-go
   * d/rules: add Go 1.23 to $PATH
-  * d/t/basic-smoke: target bullseye for debootstrap image generation
-    (LP: #2124109)
+  * d/t/basic-smoke:
+    - Target bullseye for debootstrap image generation (LP: #2124109)
+    - Change the MIRROR URL to use archive.d.o since oldoldstable is not
+      available for ppc64el and s390x through ftp.d.o
 
  -- Athos Ribeiro <athos.ribeiro@canonical.com>  Wed, 10 Sep 2025 11:50:16 -0300
 

--- a/debian/tests/basic-smoke
+++ b/debian/tests/basic-smoke
@@ -11,7 +11,7 @@ debootstrap \
 	--variant=minbase \
 	bullseye \
 	"$tempDir" \
-	http://httpredir.debian.org/debian
+	http://archive.debian.org/debian
 
 tar -cC "$tempDir" . | docker import - debian
 defer 'docker rmi debian'


### PR DESCRIPTION
Change the MIRROR URL to use archive.d.o since oldoldstable is not available for ppc64el and s390x through ftp.d.o